### PR TITLE
ceph_diagnostics_collect: add scrip version information

### DIFF
--- a/ceph_diagnostics_collect.sh
+++ b/ceph_diagnostics_collect.sh
@@ -52,6 +52,10 @@ info() {
     echo "$*" >&2
 }
 
+version() {
+    md5sum "$(command -v $0)" | cut -d' ' -f1
+}
+
 censor_config() {
     if [ -z "${CENSORED}" ]; then
         "$@"
@@ -154,6 +158,14 @@ show_stored() {
     local name="$1"
 
     cat "${RESULTS_DIR}/${name}"
+}
+
+get_script_info() {
+    local t=script_info
+
+    info "collecting script info ..."
+
+    store -S ${t}-version version
 }
 
 get_system_info() {
@@ -468,7 +480,7 @@ archive_result() {
 # Main
 #
 
-OPTIONS=$(getopt -o ac:hqr:t:uvD:G:M:O: --long all-osd-asok-stats,ceph-config-file:,help,query-inactive-pg,results-dir:,timeout:,uncensored,verbose,mds-perf-reset-and-sleep:,mgr-perf-reset-and-sleep:,mon-perf-reset-and-sleep:,osd-perf-reset-and-sleep: -- "$@")
+OPTIONS=$(getopt -o ac:hqr:t:uvD:G:M:O:V --long all-osd-asok-stats,ceph-config-file:,help,query-inactive-pg,results-dir:,timeout:,uncensored,verbose,mds-perf-reset-and-sleep:,mgr-perf-reset-and-sleep:,mon-perf-reset-and-sleep:,osd-perf-reset-and-sleep:,version -- "$@")
 if [ $? -ne 0 ]; then
     usage >&2
     exit 1
@@ -525,6 +537,10 @@ while true; do
             RESET_OSD_PERF_AND_SLEEP="$2"
             shift 2
             ;;
+	-V|--version)
+	    version
+	    exit 0
+	    ;;
         --)
             shift
             break
@@ -569,6 +585,7 @@ fi
 
 trap cleanup INT TERM EXIT
 
+get_script_info
 get_system_info
 get_ceph_info
 get_health_info


### PR DESCRIPTION
Its is not actually a version but just md5sum of the scrip file. But collecting this info is useful to understand if a user was running the latest script version when collecting data. For this one may compare the contents of script_info-version with hers output of `./ceph_diagnostics_collect.sh --version`.