### PR TITLE
ceph_diagnostics_show/commands/pg: show also bytes and objects deviation in scrub-stats

### DIFF
--- a/ceph_diagnostics_show/commands/pg
+++ b/ceph_diagnostics_show/commands/pg
@@ -131,27 +131,34 @@ def scrub_stats():
     num_objects_sum_pool = {}
     num_bytes_sum_pool = {}
     num = {}
-    # New: dictionary to store durations per pool
     pool_durations = {}
+    pool_num_objects = {}
+    pool_num_bytes = {}
 
     for pg in pg_dump['pg_map']['pg_stats']:
         if 'scrub_duration' in pg:
             duration = pg['scrub_duration']
+            num_objects = pg['stat_sum']['num_objects']
+            num_bytes = pg['stat_sum']['num_bytes']
             scrub_duration_sum += duration
             scrub_durations.append(duration)
-            num_objects_sum += pg['stat_sum']['num_objects']
-            num_bytes_sum += pg['stat_sum']['num_bytes']
+            num_objects_sum += num_objects
+            num_bytes_sum += num_bytes
             pool = pg['pgid'].split('.')[0]
 
             # Initialize pool lists if not exists
             if pool not in pool_durations:
                 pool_durations[pool] = []
+                pool_num_objects[pool] = []
+                pool_num_bytes[pool] = []
             pool_durations[pool].append(duration)
+            pool_num_objects[pool].append(num_objects)
+            pool_num_bytes[pool].append(num_bytes)
 
             num[pool] = num.get(pool, 0) + 1
             scrub_duration_sum_pool[pool] = scrub_duration_sum_pool.get(pool, 0) + duration
-            num_objects_sum_pool[pool] = num_objects_sum_pool.get(pool, 0) + pg['stat_sum']['num_objects']
-            num_bytes_sum_pool[pool] = num_bytes_sum_pool.get(pool, 0) + pg['stat_sum']['num_bytes']
+            num_objects_sum_pool[pool] = num_objects_sum_pool.get(pool, 0) + num_objects
+            num_bytes_sum_pool[pool] = num_bytes_sum_pool.get(pool, 0) + num_bytes
 
     print("total number of pgs: %d" % len(pg_dump['pg_map']['pg_stats']))
     print("total scrub duration: %d sec" % scrub_duration_sum)
@@ -162,16 +169,19 @@ def scrub_stats():
     print("average pg size: %d bytes" % (num_bytes_sum / len(pg_dump['pg_map']['pg_stats'])))
     print("per pool scrub duration:")
     for pool in num:
-        pool_std_dev = 0.0
+        duration_std_dev = 0.0
+        num_bytes_std_dev = 0.0
+        num_objects_std_dev = 0.0
         if len(pool_durations[pool]) > 1:  # Need at least 2 values for std dev
-            pool_std_dev = statistics.stdev(pool_durations[pool])
+            duration_std_dev = statistics.stdev(pool_durations[pool])
+            num_bytes_std_dev = statistics.stdev(pool_num_bytes[pool])
+            num_objects_std_dev = statistics.stdev(pool_num_objects[pool])
 
-        print("  %s: %d sec (%d pgs, %d sec/pg, %d bytes/pg, %d obj/pg, %.2f sec std_dev)" %
+        print("  %s: %d sec (%d pgs, %d±%d sec/pg, %d±%d bytes/pg, %d±%d obj/pg)" %
               (pool, scrub_duration_sum_pool[pool], num[pool],
-               scrub_duration_sum_pool[pool] / num[pool],
-               num_bytes_sum_pool[pool] / num[pool],
-               num_objects_sum_pool[pool] / num[pool],
-               pool_std_dev))
+               scrub_duration_sum_pool[pool] / num[pool], duration_std_dev,
+               num_bytes_sum_pool[pool] / num[pool], num_bytes_std_dev,
+               num_objects_sum_pool[pool] / num[pool], num_objects_std_dev))
 
 def check_pg_on_same_host():
     osd_metadata = get_osd_metadata()


### PR DESCRIPTION
Example:
```
➜  ceph-collect_20250518_101049-N0i cds pg scrub-stats 
total number of pgs: 1440
total scrub duration: 485064 sec
average scrub duration: 336 sec
total number of objects: 25435365
average number of objects per pg: 17663
total size: 49183624970444 bytes
average pg size: 34155295118 bytes
per pool scrub duration:
  20: 454979 sec (512 pgs, 888±1880 sec/pg, 90936766847±515002893 bytes/pg, 48280±215 obj/pg)
  23: 15781 sec (256 pgs, 61±143 sec/pg, 5099721106±521635495 bytes/pg, 1455±147 obj/pg)
  2: 14150 sec (256 pgs, 55±124 sec/pg, 5129804472±155333736 bytes/pg, 1245±37 obj/pg)
  17: 3 sec (128 pgs, 0±0 sec/pg, 1189±598 bytes/pg, 5±2 obj/pg)
  18: 55 sec (128 pgs, 0±1 sec/pg, 0±0 bytes/pg, 19±4 obj/pg)
  16: 0 sec (32 pgs, 0±0 sec/pg, 0±0 bytes/pg, 0±0 obj/pg)
  15: 7 sec (32 pgs, 0±1 sec/pg, 133227391±116978571 bytes/pg, 7±2 obj/pg)
  14: 0 sec (32 pgs, 0±0 sec/pg, 201±377 bytes/pg, 0±0 obj/pg)
  1: 15 sec (32 pgs, 0±1 sec/pg, 30556377±15045138 bytes/pg, 7±3 obj/pg)
  19: 68 sec (32 pgs, 2±4 sec/pg, 17397±801 bytes/pg, 644±29 obj/pg)
```