### PR TITLE
ceph_diagnostics_show: fix "ceph crash info" command

### DIFF
--- a/ceph_diagnostics_show/commands/ceph
+++ b/ceph_diagnostics_show/commands/ceph
@@ -210,7 +210,7 @@ case "$cmd" in
 	file="${CEPH_DIAGNOSTICS_COLLECT_DIR}/ceph_cluster_info-versions"
         ;;
     "crash info"*)
-	id=$(echo $cmd | sed -Ee 's/crash info //; s/:/_/g;')
+	id=$(echo $cmd | sed -Ee 's/^crash info *//')
 	if [ -z "$id" ]; then
 	    echo "crash info expects <crash_id> argument" >&2
 	    exit 1


### PR DESCRIPTION
We used to replace ':' with '_' in file names, when storing crash info, and had to do the same in cds when looking for the file name. It has been removed in the collect script some time ago and we don't need this hack in cds too.