### PR TITLE
ceph_diagnostics_collect: list client-keyrings and placement labels

### DIFF
--- a/ceph_diagnostics_collect.sh
+++ b/ceph_diagnostics_collect.sh
@@ -476,6 +476,7 @@ get_orch_info() {
     store    ${t}-host ${CEPH} orch host ls
 	store    ${t}-host-ls-detail ${CEPH} orch host ls --detail
 	store	 ${t}-osd-rm-status ${CEPH} orch osd rm status
+	store	 ${t}-client-keyring-ls ${CEPH} orch client-keyring ls
 }
 
 get_prometheus_info() {


### PR DESCRIPTION
The rules defined here govern how client keyrings are deployed based on host labels like _admin.