### PR TITLE
ceph_diagnostics_collect: collecting 'ceph osd pool stats'

### DIFF
--- a/ceph_diagnostics_collect.sh
+++ b/ceph_diagnostics_collect.sh
@@ -331,15 +331,16 @@ get_osd_info() {
 
     info "collecting osd info ..."
 
-    store -c ${t}-tree      ${CEPH} osd tree
-    store    ${t}-df        ${CEPH} osd df
-    store    ${t}-df-tree   ${CEPH} osd df tree
-    store    ${t}-dump      ${CEPH} osd dump
-    store    ${t}-stat      ${CEPH} osd stat
-    store -s ${t}-crushmap  ${CEPH} osd getcrushmap
-    store -s ${t}-map       ${CEPH} osd getmap
-    store -s ${t}-metadata  ${CEPH} osd metadata
-    store    ${t}-perf      ${CEPH} osd perf
+    store -c ${t}-tree      		${CEPH} osd tree
+    store    ${t}-df        		${CEPH} osd df
+    store    ${t}-df-tree   		${CEPH} osd df tree
+    store    ${t}-dump      		${CEPH} osd dump
+    store    ${t}-stat      		${CEPH} osd stat
+    store -s ${t}-crushmap  		${CEPH} osd getcrushmap
+    store -s ${t}-map       		${CEPH} osd getmap
+    store -s ${t}-metadata  		${CEPH} osd metadata
+    store    ${t}-perf      		${CEPH} osd perf
+    store    ${t}-osd-pool-stats    ${CEPH} osd pool stats	
 
     show_stored ${t}-crushmap | store ${t}-crushmap.txt crushtool -d -
 


### PR DESCRIPTION
'ceph osd pool stats' provides a good overview of how pools are being utilized for both client and recovery IO. This helps in understanding specific cluster behavior and offers insights into whether and how workloads might benefit from an increase in pg_num.