### PR TITLE
ceph_diagnostics_collect: fix mon dump crush_location parsing

### DIFF
--- a/ceph_diagnostics_collect.sh
+++ b/ceph_diagnostics_collect.sh
@@ -284,7 +284,7 @@ get_monitor_info() {
     store -s ${t}-map      ${CEPH} mon getmap
     store -s ${t}-metadata ${CEPH} mon metadata
 
-    mons=$(show_stored ${t}-dump | sed -nEe 's/^.* (mon\..*)$/\1/p')
+    mons=$(show_stored ${t}-dump | sed -nEe 's/^.* (mon\.[^; ]*).*$/\1/p')
 
     if [ "${RESET_MON_PERF_AND_SLEEP}" -gt 0 ]; then
         store_tell -S "${mons}" ${t} perf_reset perf reset all


### PR DESCRIPTION
## Summary

Fixes spurious `ln: File exists` errors during collection on stretch-mode clusters. On these clusters `ceph mon dump` appends a `crush_location {datacenter=...}` suffix to each mon line, e.g. `mon.<name>; crush_location {datacenter=<dc>}`. The mon-name extraction regex in [`get_monitor_info`](https://github.com/clyso/ceph_diagnostics/blob/main/ceph_diagnostics_collect.sh#L276) captured everything from `mon.` to the end of the line, so the resulting mon list contained `crush_location` and `{datacenter=...}` as bogus extra tokens once word-split by the `for d in ${mons}` loop. Since these bogus tokens were shared across mons, `store_tell` collided on the same output filenames for different mons, producing errors like:

```
ln: failed to create symbolic link '.../monitor_info-crush_location-config_diff.json': File exists
ln: failed to create symbolic link '.../monitor_info-{datacenter=<dc>}-config_diff.json': File exists
```

The regex now stops at the first space or semicolon, so only the actual mon name is captured.

## Test plan

- [x] Verified the new regex against sample `ceph mon dump` output from a stretch-mode (non-cephadm) cluster with the `crush_location` suffix — extracts only the `mon.<name>` tokens, dropping the suffix.
- [x] Verified the new regex against sample `ceph mon dump` output from a cephadm-managed cluster without the `crush_location` suffix — extraction unchanged.
